### PR TITLE
Fix bullseye install : sqlite -> sqlite3

### DIFF
--- a/scripts/_variables
+++ b/scripts/_variables
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Dependencies
-app_depencencies="sqlite idn2 php7.0-sqlite3"
+app_depencencies="sqlite3 idn2 php7.0-sqlite3"


### PR DESCRIPTION
c.f. https://packages.debian.org/buster/sqlite

>This package is SQLite version 2. Most programs that use SQLite use SQLite version 3. See the "sqlite3" package for that. 