### PR TITLE
Explain option to use version 3.3.1 or latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Use the admin panel of your Pi-hole to configure this app. You may also need to 
 ## Limitations
 
 * Activate DHCP with Pi-hole needs manual configuration of your router.
-* Pi-Hole can't be updated beyond version 3.3.1, because higher versions use an integrated version of dnsmasq. This would require disabling the version of dnsmasq used by YunoHost.
+* During the installation you may choose to install version 3.3.1 of pi-hole, which is the last version to use the system's dnsmasq. Or you may choose to install the latest version of pi-hole available, which uses [FTLDNS](https://docs.pi-hole.net/ftldns/).
 
 
 Using Pi-hole as your DHCP server


### PR DESCRIPTION
Users are no longer limited to version 3.3.1 and can now select the latest version, provided they are willing accept the use of FTLDNS. This tries to explain that.

