### PR TITLE
[pihole FTL conf] Apply official template

### DIFF
--- a/conf/pihole-FTL.conf
+++ b/conf/pihole-FTL.conf
@@ -1,34 +1,37 @@
-; Listen only for local socket connections or permit all connections
-; localonly|all
+#; Pi-hole FTL config file
+#; Comments should start with #; to avoid issues with PHP and bash reading this file
+
+#; Listen only for local socket connections or permit all connections
+#; localonly|all
 SOCKET_LISTENING=localonly
 
-; On which port should FTL be listening?
+#; On which port should FTL be listening?
 FTLPORT=__PORT__
 
-; Display all queries? Set to no to hide query display
-; yes|no
+#; Display all queries? Set to no to hide query display
+#; yes|no
 QUERY_DISPLAY=yes
 
-; Allow FTL to analyze AAAA queries from pihole.log?
-; yes|no
+#; Allow FTL to analyze AAAA queries from pihole.log?
+#; yes|no
 AAAA_QUERY_ANALYSIS=yes
 
-; How long should queries be stored in the database? Setting this to 0 disables the database altogether
+#; How long should queries be stored in the database? Setting this to 0 disables the database altogether
 MAXDBDAYS=365
 
-; Should FTL try to resolve IPv6 addresses to host names?
-; yes|no
+#; Should FTL try to resolve IPv6 addresses to host names?
+#; yes|no
 RESOLVE_IPV6=yes
 
-; Should FTL try to resolve IPv4 addresses to host names?
-; yes|no
+#; Should FTL try to resolve IPv4 addresses to host names?
+#; yes|no
 RESOLVE_IPV4=yes
 
-; How often do we store queries in FTL's database [minutes]?
+#; How often do we store queries in FTL's database [minutes]?
 DBINTERVAL=1.0
 
-; Specify path and filename of FTL's SQLite long-term database. Setting this to DBFILE= disables the database altogether
+#; Specify path and filename of FTL's SQLite long-term database. Setting this to DBFILE= disables the database altogether
 DBFILE=/etc/pihole/pihole-FTL.db
 
-; Up to how many hours of queries should be imported from the database and logs? Maximum is 744 (31 days)
+#; Up to how many hours of queries should be imported from the database and logs? Maximum is 744 (31 days)
 MAXLOGAGE=24.0


### PR DESCRIPTION
## Problem

- *Error during pihole updateGravity having caused a resulting in a Pi-hole FTL stop (DHCP does not work).*
```sh
/etc/pihole/pihole-FTL.conf: line 1: syntax error near unexpected token `;'
/etc/pihole/pihole-FTL.conf: line 1: `; Listen only for local socket connections or permit all connections'
```
- *[pihole-FTL.conf](https://github.com/YunoHost-Apps/pihole_ynh/blob/master/conf/pihole-FTL.conf)  in YunoHost package don't respect the new synthaxis of the comments fixing [this issue](https://github.com/pi-hole/pi-hole/issues/4444).*

## Solution

- *Apply [official pihole-FTL.conf template](https://github.com/pi-hole/pi-hole/blob/master/advanced/Templates/pihole-FTL.conf) : comments should start with #; to avoid issues with PHP and bash reading this file !*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)
