### PR TITLE
Fix listening interface

### DIFF
--- a/conf/dnsmasq_regenconf_hook
+++ b/conf/dnsmasq_regenconf_hook
@@ -31,6 +31,7 @@ if [ "$query_logging" = "true" ]; then
 else
 	ynh_replace_string --match_string="^log-queries" --replace_string="#log-queries" --target_file="$dnsmasq_dir/01-pihole.conf"
 fi
+echo "interface=$main_iface" >> "$dnsmasq_dir/01-pihole.conf"
 
 #
 # Tweak dnsmsasq's general conf cache-size

--- a/scripts/actions/reset_default_config
+++ b/scripts/actions/reset_default_config
@@ -57,6 +57,7 @@ then
 	echo "IPV6_ADDRESS=::1" >> "$config_file"
 	echo "PIHOLE_DNS_1=" >> "$config_file"
 	echo "PIHOLE_DNS_2=" >> "$config_file"
+	echo "DNSMASQ_LISTENING=single" >> "$config_file"
 	if [ $query_logging -eq 1 ]; then
 		query_logging=true
 	else

--- a/scripts/install
+++ b/scripts/install
@@ -232,6 +232,7 @@ echo "IPV4_ADDRESS=127.0.0.1" >> $setupVars
 echo "IPV6_ADDRESS=::1" >> $setupVars
 echo "PIHOLE_DNS_1=" >> $setupVars
 echo "PIHOLE_DNS_2=" >> $setupVars
+echo "DNSMASQ_LISTENING=single" >> $setupVars
 if [ $query_logging -eq 1 ]; then
 	query_logging=true
 else

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -297,6 +297,7 @@ then
 	echo "IPV6_ADDRESS=::1" >> $setupVars
 	echo "PIHOLE_DNS_1=" >> $setupVars
 	echo "PIHOLE_DNS_2=" >> $setupVars
+	echo "DNSMASQ_LISTENING=single" >> $setupVars
 	if [ $query_logging -eq 1 ]; then
 		query_logging=true
 	else


### PR DESCRIPTION
## Problem

- *Pi-Hole doesn't answer to any DNS request outside of localhost, making it useless.*
- *Therefor, Pi-Hole can't be used as a network wide DNS and ad blocker.*

## Solution

- *Listen on the main interface*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
