### PR TITLE
Update remove to include overlooked DNSMasq files

### DIFF
--- a/scripts/remove
+++ b/scripts/remove
@@ -92,6 +92,10 @@ ynh_secure_remove --file="$PI_HOLE_LOCAL_REPO"
 #=================================================
 ynh_script_progression --message="Removing Dnsmasq config..." --weight=2
 
+ynh_secure_remove --file="/etc/dnsmasq.d/01-pihole.conf"
+
+ynh_secure_remove --file="/etc/dnsmasq.d/02-pihole-dhcp.conf"
+
 ynh_secure_remove --file="/etc/dnsmasq.d/03-pihole-wildcard.conf"
 
 #=================================================


### PR DESCRIPTION
Why was 03 included, but not 01 or 02?

## Problem

uninstallation of Pi-hole crippled DNSMasq

## Solution

Removed 2 specific files in /etc/dnsmasq.d/

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)
should be good, I didn't change much.

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
